### PR TITLE
Parameter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Type declarations have been added to all parameters and return types.
 - Validation with `\InvalidArgumentException` for the `base_convert()`
   parameters to match the warnings added for the original PHP function in v7.4.
+  - `$number` must be a string using only *alphanumeric* characters.
   - `$fromBase` and `$toBase` must be an integer between *2* and *36*.
 ### Removed
 - **BC break**: Removed support for PHP versions < v7.1 as they are no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add support for PHP v7.1 (temporary measure to move away from PHP v5).
 - Type declarations have been added to all parameters and return types.
+- Validation with `\InvalidArgumentException` for the `base_convert()`
+  parameters to match the warnings added for the original PHP function in v7.4.
+  - `$fromBase` and `$toBase` must be an integer between *2* and *36*.
 ### Removed
 - **BC break**: Removed support for PHP versions < v7.1 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.

--- a/src/base_convert.php
+++ b/src/base_convert.php
@@ -27,6 +27,9 @@ function base_convert(string $number, int $fromBase, int $toBase): string
     if (filter_var($toBase, FILTER_VALIDATE_INT, $baseOptions) === false) {
         throw new \InvalidArgumentException("Invalid `to base' ({$toBase})");
     }
+    if (preg_match('/^[a-z0-9]+$/', $number) === 0) {
+        throw new \InvalidArgumentException('Invalid characters passed for attempted conversion');
+    }
 
     if ($fromBase === $toBase) {
         return $number;

--- a/src/base_convert.php
+++ b/src/base_convert.php
@@ -12,30 +12,44 @@ namespace Phlib;
  * @see http://php.net/manual/en/function.base-convert.php
  * @see http://php.net/manual/en/function.base-convert.php#109660
  */
-function base_convert(string $number, int $frombase, int $tobase): string
+function base_convert(string $number, int $fromBase, int $toBase): string
 {
-    if ($frombase === $tobase) {
+    // Error messages to match original PHP function
+    $baseOptions = [
+        'options' => [
+            'min_range' => 2,
+            'max_range' => 36,
+        ],
+    ];
+    if (filter_var($fromBase, FILTER_VALIDATE_INT, $baseOptions) === false) {
+        throw new \InvalidArgumentException("Invalid `from base' ({$fromBase})");
+    }
+    if (filter_var($toBase, FILTER_VALIDATE_INT, $baseOptions) === false) {
+        throw new \InvalidArgumentException("Invalid `to base' ({$toBase})");
+    }
+
+    if ($fromBase === $toBase) {
         return $number;
     }
 
     $number = trim($number);
-    if ($frombase !== 10) {
+    if ($fromBase !== 10) {
         $len = strlen($number);
         $fromDec = '0';
         for ($i = 0; $i < $len; $i++) {
-            $v = \base_convert($number[$i], $frombase, 10);
-            $fromDec = bcadd(bcmul($fromDec, (string)$frombase, 0), $v, 0);
+            $v = \base_convert($number[$i], $fromBase, 10);
+            $fromDec = bcadd(bcmul($fromDec, (string)$fromBase, 0), $v, 0);
         }
     } else {
         $fromDec = $number;
     }
 
-    if ($tobase !== 10) {
+    if ($toBase !== 10) {
         $result = '';
         while (bccomp($fromDec, '0', 0) > 0) {
-            $v = (string)intval(bcmod($fromDec, (string)$tobase));
-            $result = \base_convert($v, 10, $tobase) . $result;
-            $fromDec = bcdiv($fromDec, (string)$tobase, 0);
+            $v = (string)intval(bcmod($fromDec, (string)$toBase));
+            $result = \base_convert($v, 10, $toBase) . $result;
+            $fromDec = bcdiv($fromDec, (string)$toBase, 0);
         }
     } else {
         $result = $fromDec;

--- a/tests/BaseConvertTest.php
+++ b/tests/BaseConvertTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phlib;
 
+use PHPUnit\Framework\Error\Deprecated as DeprecatedError;
 use PHPUnit\Framework\TestCase;
 
 class BaseConvertTest extends TestCase
@@ -12,6 +13,57 @@ class BaseConvertTest extends TestCase
     {
         $number = '1234567890';
         static::assertSame(\base_convert($number, 10, 36), \Phlib\base_convert($number, 10, 36));
+    }
+
+    /**
+     * @dataProvider dataValidNumberCharacters
+     */
+    public function testValidNumberCharacters(string $number, bool $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Invalid characters passed for attempted conversion');
+        }
+
+        \Phlib\base_convert($number, 36, 10);
+
+        if ($isValid) {
+            // Valid number should reach this line without error
+            static::assertTrue(true);
+        }
+    }
+
+    public function dataValidNumberCharacters(): array
+    {
+        return [
+            'numeric' => ['123', true],
+            'alphanumeric' => ['123abc', true],
+            'float' => ['3.6', false],
+            'scientific' => ['1.2e3', false],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testOriginalNumberCharactersWarning(): void
+    {
+        /**
+         * PHP's own validation for `$number` is more accurate
+         * as it warns against characters that are not allowed by the given from base,
+         * e.g. *base2* only allows *0* and *1*.
+         */
+        $originalErrorLevel = error_reporting();
+        error_reporting(E_ALL);
+
+        $this->expectException(DeprecatedError::class);
+        $this->expectExceptionMessage('Invalid characters passed for attempted conversion, these have been ignored');
+
+        try {
+            \Phlib\base_convert('123', 2, 10);
+        } finally {
+            error_reporting($originalErrorLevel);
+        }
     }
 
     /**

--- a/tests/BaseConvertTest.php
+++ b/tests/BaseConvertTest.php
@@ -14,6 +14,52 @@ class BaseConvertTest extends TestCase
         static::assertSame(\base_convert($number, 10, 36), \Phlib\base_convert($number, 10, 36));
     }
 
+    /**
+     * @dataProvider dataValidBase
+     */
+    public function testValidFromBase(int $fromBase, bool $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage("Invalid `from base' ({$fromBase})");
+        }
+
+        \Phlib\base_convert('1', $fromBase, 10);
+
+        if ($isValid) {
+            // Valid base should reach this line without error
+            static::assertTrue(true);
+        }
+    }
+
+    /**
+     * @dataProvider dataValidBase
+     */
+    public function testValidToBase(int $toBase, bool $isValid): void
+    {
+        if (!$isValid) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage("Invalid `to base' ({$toBase})");
+        }
+
+        \Phlib\base_convert('1', 10, $toBase);
+
+        if ($isValid) {
+            // Valid base should reach this line without error
+            static::assertTrue(true);
+        }
+    }
+
+    public function dataValidBase(): array
+    {
+        return [
+            'too-small' => [1, false],
+            'min' => [2, true],
+            'max' => [36, true],
+            'too-large' => [37, false],
+        ];
+    }
+
     public function testLargeNumberConvertsBack(): void
     {
         $largeNumber = '111222333444555666777888999000';


### PR DESCRIPTION
Add validation with `\InvalidArgumentException` to match the warnings added for the original PHP function in v7.4.