### PR TITLE
PHP 8

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,6 +12,8 @@ jobs:
       matrix:
         php:
           - '7.4'
+          - '8.0'
+          - '8.1'
 
     name: PHP ${{ matrix.php }} tests
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,9 +11,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.1'
-          - '7.2'
-          - '7.3'
           - '7.4'
 
     name: PHP ${{ matrix.php }} tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.idea
-composer.lock
-/vendor/
+/vendor
+/composer.lock
+/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Add support for PHP v7.1 (temporary measure to move away from PHP v5).
+- Add support for PHP v7.4 .
 - Type declarations have been added to all parameters and return types.
 - Validation with `\InvalidArgumentException` for the `base_convert()`
   parameters to match the warnings added for the original PHP function in v7.4.
   - `$number` must be a string using only *alphanumeric* characters.
   - `$fromBase` and `$toBase` must be an integer between *2* and *36*.
 ### Removed
-- **BC break**: Removed support for PHP versions < v7.1 as they are no longer
+- **BC break**: Removed support for PHP versions <= v7.3 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.
 
 ## [1.0.0] - 2016-02-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Add support for PHP v7.4 .
+- Add support for PHP v7.4 & v8.0 .
 - Type declarations have been added to all parameters and return types.
 - Validation with `\InvalidArgumentException` for the `base_convert()`
   parameters to match the warnings added for the original PHP function in v7.4.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-bcmath": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8",
+        "phpunit/phpunit": "^9",
         "symplify/easy-coding-standard": "^9"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "files": ["src/base_convert.php"]
     },
     "require": {
-        "php" : "^7.1",
+        "php" : "^7.4",
         "ext-bcmath": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "files": ["src/base_convert.php"]
     },
     "require": {
-        "php" : "^7.4",
+        "php": "^7.4 || ^8.0",
         "ext-bcmath": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-bcmath": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^8",
         "symplify/easy-coding-standard": "^9"
     },
     "autoload-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit
+    bootstrap="vendor/autoload.php"
+    convertDeprecationsToExceptions="true"
+    colors="true"
+>
     <testsuites>
         <testsuite name="base_convert Test Suite">
             <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     bootstrap="vendor/autoload.php"
+    beStrictAboutOutputDuringTests="true"
     convertDeprecationsToExceptions="true"
     colors="true"
 >
     <testsuites>
-        <testsuite name="base_convert Test Suite">
+        <testsuite name="Phlib Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/BaseConvertTest.php
+++ b/tests/BaseConvertTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phlib;
 
-use PHPUnit\Framework\Error\Deprecated as DeprecatedError;
 use PHPUnit\Framework\TestCase;
 
 class BaseConvertTest extends TestCase
@@ -53,8 +52,8 @@ class BaseConvertTest extends TestCase
         $originalErrorLevel = error_reporting();
         error_reporting(E_ALL);
 
-        $this->expectException(DeprecatedError::class);
-        $this->expectExceptionMessage('Invalid characters passed for attempted conversion, these have been ignored');
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage('Invalid characters passed for attempted conversion, these have been ignored');
 
         try {
             \Phlib\base_convert('123', 2, 10);

--- a/tests/BaseConvertTest.php
+++ b/tests/BaseConvertTest.php
@@ -43,9 +43,6 @@ class BaseConvertTest extends TestCase
         ];
     }
 
-    /**
-     * @requires PHP 7.4
-     */
     public function testOriginalNumberCharactersWarning(): void
     {
         /**


### PR DESCRIPTION
- Drop support for PHP <= v7.3, add support for v8.
- Upgrade PHPUnit to v9 to support PHP v8.
